### PR TITLE
PHP 7.2 deprecation fixes

### DIFF
--- a/tests/dataset_pdo_test.php
+++ b/tests/dataset_pdo_test.php
@@ -109,7 +109,9 @@ class ezcGraphDatabaseTest extends ezcTestCase
         $count = 0;
         foreach ( $dataset as $key => $value )
         {
-            list( $compareKey, $compareValue ) = each( $dataSetArray );
+            $compareValue = current( $dataSetArray );
+            $compareKey = key( $dataSetArray );
+            next( $dataSetArray );
 
             $this->assertEquals(
                 $compareKey,
@@ -154,7 +156,8 @@ class ezcGraphDatabaseTest extends ezcTestCase
         $count = 0;
         foreach ( $dataset as $key => $value )
         {
-            list( $compareKey, $compareValue ) = each( $dataSetArray );
+            $compareValue = current( $dataSetArray );
+            next( $dataSetArray );
 
             $this->assertEquals(
                 $count,
@@ -224,7 +227,9 @@ class ezcGraphDatabaseTest extends ezcTestCase
         $count = 0;
         foreach ( $dataset as $key => $value )
         {
-            list( $compareKey, $compareValue ) = each( $dataSetArray );
+            $compareValue = current( $dataSetArray );
+            $compareKey = key( $dataSetArray );
+            next( $dataSetArray );
 
             $this->assertEquals(
                 $compareKey,
@@ -274,7 +279,8 @@ class ezcGraphDatabaseTest extends ezcTestCase
         $count = 0;
         foreach ( $dataset as $key => $value )
         {
-            list( $compareKey, $compareValue ) = each( $dataSetArray );
+            $compareValue = current( $dataSetArray );
+            next( $dataSetArray );
 
             $this->assertEquals(
                 $count,


### PR DESCRIPTION
Fixes:

```
 PHP | File:Line                                                                                          |             Type | Issue
 7.2 | /tests/dataset_pdo_test.php:112                                                                    | function         | Function each() is deprecated. 
 7.2 | /tests/dataset_pdo_test.php:157                                                                    | function         | Function each() is deprecated. 
 7.2 | /tests/dataset_pdo_test.php:227                                                                    | function         | Function each() is deprecated. 
 7.2 | /tests/dataset_pdo_test.php:277                                                                    | function         | Function each() is deprecated. 
```